### PR TITLE
AoE improvements

### DIFF
--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -80,7 +80,7 @@ actions.aoe+=/call_action_list,name=green,if=talent.ancient_flame&!buff.ancient_
 actions.aoe+=/azure_strike,target_if=max:target.health.pct
 
 # Eternity Surge, use rank most applicable to targets.
-actions.es=eternity_surge,empower_to=1,target_if=max:target.health.pct,if=active_enemies<=1+talent.eternitys_span|buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste|buff.dragonrage.up&(active_enemies==5&!talent.font_of_magic|active_enemies>(3+talent.font_of_magic)*(1+talent.eternitys_span))|active_enemies>=6&!talent.eternitys_span
+actions.es=eternity_surge,empower_to=1,target_if=max:target.health.pct,if=active_enemies<=1+talent.eternitys_span|buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste|buff.dragonrage.up&(active_enemies>(3+talent.font_of_magic)*(1+talent.eternitys_span))|active_enemies>=6&!talent.eternitys_span
 actions.es+=/eternity_surge,empower_to=2,target_if=max:target.health.pct,if=active_enemies<=2+2*talent.eternitys_span|buff.dragonrage.remains<2.5*spell_haste&buff.dragonrage.remains>=1.75*spell_haste
 actions.es+=/eternity_surge,empower_to=3,target_if=max:target.health.pct,if=active_enemies<=3+3*talent.eternitys_span|!talent.font_of_magic|buff.dragonrage.remains<=3.25*spell_haste&buff.dragonrage.remains>=2.5*spell_haste
 actions.es+=/eternity_surge,empower_to=4,target_if=max:target.health.pct

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -19,7 +19,7 @@ actions.precombat+=/variable,name=r1_cast_time,value=1.0*spell_haste
 # Variable for when to start holding empowers for upcoming DR in AoE. - From my testing 4sec seems like the sweetspot, but it's very minor diff so far - Holding for more than 6 seconds it begins to become a loss.
 actions.precombat+=/variable,name=dr_prep_time_aoe,default=4,op=reset
 # Variable for when to start holding empowers for upcoming DR in ST.
-actions.precombat+=/variable,name=dr_prep_time_st,default=10,op=reset
+actions.precombat+=/variable,name=dr_prep_time_st,default=8,op=reset
 actions.precombat+=/variable,name=has_external_pi,value=cooldown.invoke_power_infusion_0.duration>0
 # Get Some Scarlet Adaptation Prepull
 actions.precombat+=/verdant_embrace,if=talent.scarlet_adaptation
@@ -30,9 +30,10 @@ actions.precombat+=/living_flame,if=!talent.firestorm|talent.engulf&talent.ruby_
 # Delay pot in ST if you are about to SS - mostly relevant for opener where you want DR->FB->SS->rotation
 actions=potion,if=buff.dragonrage.up&(!cooldown.shattering_star.up|active_enemies>=2)|fight_remains<35
 # Variable that evaluates when next dragonrage is by working out the maximum between the dragonrage cd and your empowers, ignoring CDR effect estimates.
-actions+=/variable,name=next_dragonrage,value=cooldown.dragonrage.remains<?(cooldown.eternity_surge.remains-4)<?(cooldown.fire_breath.remains-4)
+actions+=/variable,name=next_dragonrage,value=cooldown.dragonrage.remains<?((cooldown.eternity_surge.remains-8)>?(cooldown.fire_breath.remains-8))
 # Invoke External Power Infusions if they're available during dragonrage
-actions+=/invoke_external_buff,name=power_infusion,if=buff.dragonrage.up&(buff.emerald_trance_stacking.stack>=3&set_bonus.tier31_2pc|!cooldown.fire_breath.up&!cooldown.shattering_star.up&(!set_bonus.tier31_2pc|!talent.event_horizon))
+actions+=/invoke_external_buff,name=power_infusion,if=buff.dragonrage.up&!cooldown.fire_breath.up&!cooldown.shattering_star.up
+actions+=/variable,name=pool_for_id,if=talent.imminent_destruction&talent.melt_armor&talent.maneuverability,default=0,op=set,value=cooldown.deep_breath.remains<8&essence.deficit>=1&!buff.essence_burst.up
 # Rupt to make the raidleader happy
 actions+=/quell,use_off_gcd=1,if=target.debuff.casting.react
 actions+=/call_action_list,name=trinkets
@@ -40,35 +41,36 @@ actions+=/run_action_list,name=aoe,if=active_enemies>=3
 actions+=/run_action_list,name=st
 
 # AOE action list; This is kind of a mess again and should prolly be rewritten completely Open with star before DR to save a global and start with a free EB
-actions.aoe=shattering_star,target_if=max:target.health.pct,if=cooldown.dragonrage.up
+actions.aoe=shattering_star,target_if=max:target.health.pct,if=cooldown.dragonrage.up&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
+actions.aoe+=/hover,use_off_gcd=1,if=raid_event.movement.in<6&!buff.hover.up&gcd.remains>=0.5&(buff.mass_disintegrate_stacks.up&talent.mass_disintegrate|active_enemies<=4)
 # Spend firestorm procs ASAP
 actions.aoe+=/firestorm,if=buff.snapfire.up
-# Hard cast only outside of SS and DR windows
-actions.aoe+=/firestorm,if=!buff.dragonrage.up&debuff.shattering_star_debuff.down&talent.feed_the_flames&((!talent.dragonrage|cooldown.dragonrage.remains>=10)&(essence>=3|buff.essence_burst.up|talent.shattering_star&cooldown.shattering_star.remains<=6)|talent.dragonrage&cooldown.dragonrage.remains<=cast_time&cooldown.fire_breath.remains<6&cooldown.eternity_surge.remains<12)&!debuff.in_firestorm.up
-actions.aoe+=/deep_breath,if=talent.maneuverability&talent.melt_armor&(talent.onyx_legacy|cooldown.dragonrage.remains<=2&((cooldown.fire_breath.remains<6|cooldown.eternity_surge.remains<6&(!set_bonus.tww1_4pc|!talent.mass_disintegrate))&(cooldown.fire_breath.remains<10&(cooldown.eternity_surge.remains<10|set_bonus.tww1_4pc&talent.mass_disintegrate))&(cooldown.deep_breath.remains>10|!talent.melt_armor)&target.time_to_die>=32|fight_remains<32))
+# Acquire the buff
+actions.aoe+=/firestorm,if=talent.feed_the_flames
+# Grab Irid Red before Dragonrage without griefing extension
+actions.aoe+=/call_action_list,name=fb,if=talent.dragonrage&cooldown.dragonrage.up&talent.iridescence
+actions.aoe+=/deep_breath,if=talent.maneuverability&talent.melt_armor
 actions.aoe+=/dragonrage,if=target.time_to_die>=32|fight_remains<30
 # Use tip to get that sweet aggro
 actions.aoe+=/tip_the_scales,if=buff.dragonrage.up&(active_enemies<=3+3*talent.eternitys_span|!cooldown.fire_breath.up)
 # Cast Fire Breath - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
-actions.aoe+=/call_action_list,name=fb,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_aoe|!talent.animosity|talent.diverted_power&cooldown.dragonrage.remains>=5)&((buff.power_swell.remains<variable.r1_cast_time|(!talent.volatility&active_enemies=3))&buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
+actions.aoe+=/call_action_list,name=fb,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>(variable.dr_prep_time_aoe)|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
 # Cast Eternity Surge - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
-actions.aoe+=/call_action_list,name=es,if=buff.dragonrage.up|!talent.dragonrage|talent.diverted_power&cooldown.dragonrage.remains>=5|(cooldown.dragonrage.remains>variable.dr_prep_time_aoe&(buff.power_swell.remains<variable.r1_cast_time|(!talent.volatility&active_enemies=3))&buff.blazing_shards.remains<variable.r1_cast_time)&(target.time_to_die>=8|fight_remains<30)
+actions.aoe+=/call_action_list,name=es,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>variable.dr_prep_time_aoe|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
 # Cast DB if not in DR and not going to overflow essence.
 actions.aoe+=/deep_breath,if=!buff.dragonrage.up&essence.deficit>3
 # Send SS when it doesn't overflow EB, without vigor send on CD
-actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor
+actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_burst.stack<buff.essence_burst.max_stack&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
 actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
-# Cast Firestorm before spending ressources
-actions.aoe+=/firestorm,if=talent.feed_the_flames&(cooldown.dragonrage.remains>=20|cooldown.dragonrage.remains<=10)&(buff.essence_burst.up|essence>=2|cooldown.dragonrage.remains<=10)|buff.snapfire.up
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate
 # Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 15 stacks of CB
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=3&talent.volatility
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4&!variable.pool_for_id
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=3&talent.volatility&!variable.pool_for_id
 actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=15
-# Cast LF with leaping flames up if: not playing burnout, burnout is up, more than 4 enemies, or scarlet adaptation is up.
-actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|active_enemies>=4&cooldown.fire_breath.remains<=gcd.max*3|buff.scarlet_adaptation.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence<essence.max-1
+# Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
+actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1
 # Yoinked the disintegrate logic from ST
-actions.aoe+=/disintegrate,target_if=max:target.health.pct,chain=1,early_chain_if=evoker.use_early_chaining&ticks>=2&buff.dragonrage.up&(raid_event.movement.in>2|buff.hover.up),interrupt_if=evoker.use_clipping&buff.dragonrage.up&ticks>=2&(raid_event.movement.in>2|buff.hover.up),if=raid_event.movement.in>2|buff.hover.up
+actions.aoe+=/disintegrate,target_if=max:target.health.pct,chain=1,early_chain_if=evoker.use_early_chaining&ticks>=2&(raid_event.movement.in>2|buff.hover.up),interrupt_if=evoker.use_clipping&buff.dragonrage.up&ticks>=2&(raid_event.movement.in>2|buff.hover.up),if=(raid_event.movement.in>2|buff.hover.up)&&!variable.pool_for_id
 # Cast LF with burnout and snapfire proc for those juicy insta firestorms
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=talent.snapfire&buff.burnout.up
 actions.aoe+=/firestorm
@@ -84,9 +86,9 @@ actions.es+=/eternity_surge,empower_to=3,target_if=max:target.health.pct,if=acti
 actions.es+=/eternity_surge,empower_to=4,target_if=max:target.health.pct
 
 # Fire Breath, use rank appropriate to target count/talents.
-actions.fb=fire_breath,empower_to=1,target_if=max:target.health.pct,if=(buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste)|active_enemies=1
-actions.fb+=/fire_breath,empower_to=2,target_if=max:target.health.pct,if=active_enemies=2|(buff.dragonrage.remains<2.5*spell_haste&buff.dragonrage.remains>=1.75*spell_haste)
-actions.fb+=/fire_breath,empower_to=3,target_if=max:target.health.pct,if=!talent.font_of_magic|(buff.dragonrage.remains<=3.25*spell_haste&buff.dragonrage.remains>=2.5*spell_haste)
+actions.fb=fire_breath,empower_to=1,target_if=max:target.health.pct,if=(buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste)|active_enemies=1|talent.scorching_embers&!dot.fire_breath_damage.ticking
+actions.fb+=/fire_breath,empower_to=2,target_if=max:target.health.pct,if=active_enemies=2|(buff.dragonrage.remains<2.5*spell_haste&buff.dragonrage.remains>=1.75*spell_haste)|talent.scorching_embers
+actions.fb+=/fire_breath,empower_to=3,target_if=max:target.health.pct,if=!talent.font_of_magic|(buff.dragonrage.remains<=3.25*spell_haste&buff.dragonrage.remains>=2.5*spell_haste)|talent.scorching_embers
 actions.fb+=/fire_breath,empower_to=4,target_if=max:target.health.pct
 
 # Green Spells used to trigger Ancient Flame
@@ -96,23 +98,19 @@ actions.green+=/verdant_embrace
 # ST Action List, it's a mess, but it's getting better!
 actions.st=use_item,name=kharnalex_the_first_light,if=!buff.dragonrage.up&debuff.shattering_star_debuff.down&raid_event.movement.in>6
 # Movement Logic, Time spiral logic might need some tweaking actions.st+=/time_spiral,if=raid_event.movement.in<3&cooldown.hover.remains>=3&!buff.hover.up
-actions.st+=/hover,use_off_gcd=1,if=raid_event.movement.in<2&!buff.hover.up
-# Spend firestorm procs ASAP
-actions.st+=/firestorm,if=buff.snapfire.up
-# Hard cast only outside of SS and DR windows
-actions.st+=/firestorm,if=!buff.dragonrage.up&debuff.shattering_star_debuff.down&talent.feed_the_flames&((!talent.dragonrage|cooldown.dragonrage.remains>=10)&(essence>=3|buff.essence_burst.up|talent.shattering_star&cooldown.shattering_star.remains<=6)|talent.dragonrage&cooldown.dragonrage.remains<=cast_time&cooldown.fire_breath.remains<6&cooldown.eternity_surge.remains<12)&!debuff.in_firestorm.up
-actions.st+=/deep_breath,if=talent.maneuverability&talent.melt_armor&(talent.onyx_legacy|cooldown.dragonrage.remains<=2&((cooldown.fire_breath.remains<6|cooldown.eternity_surge.remains<6&(!set_bonus.tww1_4pc|!talent.mass_disintegrate))&(cooldown.fire_breath.remains<10&(cooldown.eternity_surge.remains<10|set_bonus.tww1_4pc&talent.mass_disintegrate))&(cooldown.deep_breath.remains>10|!talent.melt_armor)&target.time_to_die>=32|fight_remains<32))
+actions.st+=/hover,use_off_gcd=1,if=raid_event.movement.in<6&!buff.hover.up&gcd.remains>=0.5
+actions.st+=/deep_breath,if=talent.maneuverability&talent.melt_armor
+#&(talent.onyx_legacy|cooldown.dragonrage.remains<=2&((cooldown.fire_breath.remains<6|cooldown.eternity_surge.remains<6&(!set_bonus.tww1_4pc|!talent.mass_disintegrate))&(cooldown.fire_breath.remains<10&(cooldown.eternity_surge.remains<10|set_bonus.tww1_4pc&talent.mass_disintegrate))&(cooldown.deep_breath.remains>10|!talent.melt_armor)&target.time_to_die>=32|fight_remains<32))
 # Relaxed Dragonrage Entry Requirements, cannot reliably reach third extend under normal conditions (Bloodlust + Power Infusion/Very high haste gear) DS optimization: Only cast if current fight will last 32s+ or encounter ends in less than 30s
 actions.st+=/dragonrage,if=(cooldown.fire_breath.remains<4|cooldown.eternity_surge.remains<4&(!set_bonus.tww1_4pc|!talent.mass_disintegrate))&(cooldown.fire_breath.remains<8&(cooldown.eternity_surge.remains<8|set_bonus.tww1_4pc&talent.mass_disintegrate))&target.time_to_die>=32|fight_remains<32
 # Tip second FB if not playing font of magic or if playing EBF, otherwise tip ES.
 actions.st+=/tip_the_scales,if=(!talent.dragonrage|buff.dragonrage.up)&(cooldown.fire_breath.remains<cooldown.eternity_surge.remains|(cooldown.eternity_surge.remains<cooldown.fire_breath.remains&talent.font_of_magic))
 # Throw Star on CD, Don't overcap with Arcane Vigor.
-actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.eternity_surge.up|!buff.dragonrage.up|!talent.event_horizon&(!talent.traveling_flame|!cooldown.engulf.up))&(cooldown.dragonrage.remains>=15|cooldown.fire_breath.remains>=8|buff.dragonrage.up&(cooldown.fire_breath.remains<=gcd&buff.tip_the_scales.up|cooldown.tip_the_scales.remains>=15&!buff.tip_the_scales.up)|!talent.traveling_flame)&(!cooldown.fire_breath.up|buff.tip_the_scales.up)
-actions.st+=/variable,name=bombardment_clause,value=(!talent.bombardments|talent.extended_battle|debuff.bombardments.remains<=7&!buff.mass_disintegrate_stacks.up|buff.dragonrage.up),if=talent.bombardments
+actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.eternity_surge.up|!buff.dragonrage.up|talent.mass_disintegrate|!talent.event_horizon&(!talent.traveling_flame|!cooldown.engulf.up))&(cooldown.dragonrage.remains>=15|cooldown.fire_breath.remains>=8|buff.dragonrage.up&(cooldown.fire_breath.remains<=gcd&buff.tip_the_scales.up|cooldown.tip_the_scales.remains>=15&!buff.tip_the_scales.up)|!talent.traveling_flame)&(!cooldown.fire_breath.up|buff.tip_the_scales.up)
 # Fire breath logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
-actions.st+=/call_action_list,name=fb,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(!cooldown.eternity_surge.up|!talent.event_horizon&!talent.traveling_flame|!buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)&(!talent.bombardments|variable.bombardment_clause|!dot.fire_breath_damage.ticking)
+actions.st+=/call_action_list,name=fb,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(!cooldown.eternity_surge.up|!talent.event_horizon&!talent.traveling_flame|talent.mass_disintegrate|!buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
 # Eternity Surge logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
-actions.st+=/call_action_list,name=es,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity|set_bonus.tww1_4pc&talent.mass_disintegrate)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)&(!talent.bombardments|variable.bombardment_clause|set_bonus.tww1_4pc)
+actions.st+=/call_action_list,name=es,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity|set_bonus.tww1_4pc&talent.mass_disintegrate)&(target.time_to_die>=8|fight_remains<30)
 # Wait for FB/ES to be ready if spending another GCD would result in the cast no longer fitting inside of DR
 actions.st+=/wait,sec=cooldown.fire_breath.remains,if=talent.animosity&buff.dragonrage.up&buff.dragonrage.remains<gcd.max+variable.r1_cast_time*buff.tip_the_scales.down&buff.dragonrage.remains-cooldown.fire_breath.remains>=variable.r1_cast_time*buff.tip_the_scales.down
 actions.st+=/wait,sec=cooldown.eternity_surge.remains,if=talent.animosity&buff.dragonrage.up&buff.dragonrage.remains<gcd.max+variable.r1_cast_time&buff.dragonrage.remains-cooldown.eternity_surge.remains>variable.r1_cast_time*buff.tip_the_scales.down
@@ -122,11 +120,17 @@ actions.st+=/azure_strike,if=buff.dragonrage.up&buff.dragonrage.remains<(buff.es
 actions.st+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.enkindle|dot.enkindle.ticking&(prev_gcd.1.disintegrate|prev_gcd.1.engulf|prev_gcd.2.disintegrate|!talent.fan_the_flames|active_enemies>1))&(!talent.ruby_embers|dot.living_flame_damage.ticking)&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
 # Spend burnout procs without overcapping resources
 actions.st+=/living_flame,if=buff.burnout.up&buff.leaping_flames.up&!buff.essence_burst.up&buff.dragonrage.up
+# Hard cast only outside of SS and DR windows
+actions.st+=/firestorm,if=!buff.dragonrage.up&debuff.shattering_star_debuff.down&talent.feed_the_flames&((!talent.dragonrage|cooldown.dragonrage.remains>=10)&(essence>=3|buff.essence_burst.up|talent.shattering_star&cooldown.shattering_star.remains<=6)|talent.dragonrage&cooldown.dragonrage.remains<=cast_time&cooldown.fire_breath.remains<6&cooldown.eternity_surge.remains<12)&!debuff.in_firestorm.up
 actions.st+=/deep_breath,if=!buff.dragonrage.up&(talent.imminent_destruction&!debuff.shattering_star_debuff.up|talent.melt_armor&talent.maneuverability)
 # Spend pyre if raging inferno debuff is active and you have 20 stacks of CB on 2T
 actions.st+=/pyre,if=debuff.in_firestorm.up&talent.feed_the_flames&buff.charged_blast.stack==20&active_enemies>=2
+# Mass Disintegrates
+actions.st+=/disintegrate,target_if=min:buff.bombardments.remains,early_chain_if=ticks_remain<=1&buff.mass_disintegrate_stacks.up,if=(raid_event.movement.in>2|buff.hover.up)&buff.mass_disintegrate_stacks.up&talent.mass_disintegrate
 # Dis logic Early Chain if needed for resources management. Clip after in DR after third tick for more important buttons.
-actions.st+=/disintegrate,chain=1,early_chain_if=evoker.use_early_chaining&ticks>=2&(buff.dragonrage.up|talent.diverted_power)&(raid_event.movement.in>2|buff.hover.up),interrupt_if=evoker.use_clipping&(buff.dragonrage.up|talent.diverted_power)&ticks>=2&(raid_event.movement.in>2|buff.hover.up)&!buff.mass_disintegrate_ticks.up,if=(raid_event.movement.in>2|buff.hover.up)&((essence%3+buff.essence_burst.stack)>1|!talent.bombardments|debuff.bombardments.remains>3|buff.mass_disintegrate_stacks.up|buff.dragonrage.up)
+actions.st+=/disintegrate,target_if=min:buff.bombardments.remains,chain=1,early_chain_if=evoker.use_early_chaining&ticks>=2&(raid_event.movement.in>2|buff.hover.up),interrupt_if=evoker.use_clipping&ticks>=2&(raid_event.movement.in>2|buff.hover.up),if=(raid_event.movement.in>2|buff.hover.up)&!variable.pool_for_id
+# Spend firestorm procs ASAP
+actions.st+=/firestorm,if=buff.snapfire.up|!debuff.in_firestorm.up&talent.feed_the_flames
 # Use Deep Breath on 2T, unless adds will come before it'll be ready again or if talented ID.
 actions.st+=/deep_breath,if=!buff.dragonrage.up&active_enemies>=2&((raid_event.adds.in>=120&!talent.onyx_legacy)|(raid_event.adds.in>=60&talent.onyx_legacy))
 actions.st+=/deep_breath,if=!buff.dragonrage.up&(talent.imminent_destruction&!debuff.shattering_star_debuff.up|talent.melt_armor|talent.maneuverability)
@@ -142,12 +146,12 @@ actions.trinkets=use_item,name=dreambinder_loom_of_the_great_cycle,use_off_gcd=1
 actions.trinkets+=/use_item,target_if=min:target.health.pct,name=iridal_the_earths_master,use_off_gcd=1,if=gcd.remains>0.5
 actions.trinkets+=/use_item,name=spymasters_web,if=buff.spymasters_report.stack=1&buff.dragonrage.up&!buff.spymasters_web.up|buff.dragonrage.up&(fight_remains<130)|(fight_remains<=20|cooldown.engulf.up&talent.engulf&fight_remains<=40&cooldown.dragonrage.remains>=40)
 # Nymues is used before Dragonrage unless you have PI and Event Horizon, then it is used on 2 Stacks of Emerald Trance. In AoE it is used before DR.
-actions.trinkets+=/use_item,name=nymues_unraveling_spindle,if=(buff.emerald_trance_stacking.stack>=2&variable.has_external_pi&talent.event_horizon|cooldown.dragonrage.remains<=3&(cooldown.fire_breath.remains<4|cooldown.eternity_surge.remains<4)&(cooldown.fire_breath.remains<8&cooldown.eternity_surge.remains<8)&target.time_to_die>=32&(!variable.has_external_pi&active_enemies<=2|!talent.event_horizon|!set_bonus.tier31_2pc))|cooldown.dragonrage.remains<=3&active_enemies>=3|fight_remains<=20
+actions.trinkets+=/use_item,name=nymues_unraveling_spindle,if=(cooldown.dragonrage.remains<=3&(cooldown.fire_breath.remains<4|cooldown.eternity_surge.remains<4)&(cooldown.fire_breath.remains<8&cooldown.eternity_surge.remains<8)&target.time_to_die>=32)|cooldown.dragonrage.remains<=3&active_enemies>=3|fight_remains<=20
 # Belorrelos is used on CD if not playing Nymues, it is used after Nymues if it is played. On AoE use after other use trinket.
 actions.trinkets+=/use_item,name=belorrelos_the_suncaller,if=(((trinket.2.cooldown.remains|!variable.trinket_2_buffs)&(trinket.1.cooldown.remains|!variable.trinket_1_buffs)|active_enemies<=2)&(trinket.nymues_unraveling_spindle.cooldown.remains|!equipped.nymues_unraveling_spindle))|fight_remains<=20
 # The trinket with the highest estimated value, will be used first and paired with Dragonrage. Trinkets are used on 4 stacks of Emerald Trance, unless playing double buff trinket, then one is used after SS/FB and the next on CD. Or with DR in AoE
-actions.trinkets+=/use_item,slot=trinket1,if=buff.dragonrage.up&((buff.emerald_trance_stacking.stack>=4&set_bonus.tier31_2pc)|(variable.trinket_2_buffs&!cooldown.fire_breath.up&!cooldown.shattering_star.up&!equipped.nymues_unraveling_spindle&trinket.2.cooldown.remains)|(!cooldown.fire_breath.up&!cooldown.shattering_star.up&!set_bonus.tier31_2pc)|active_enemies>=3)&(!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1|variable.trinket_2_exclude)&!variable.trinket_1_manual|trinket.1.proc.any_dps.duration>=fight_remains|trinket.1.cooldown.duration<=60&(variable.next_dragonrage>20|!talent.dragonrage)&(!buff.dragonrage.up|variable.trinket_priority=1)&!variable.trinket_1_manual
-actions.trinkets+=/use_item,slot=trinket2,if=buff.dragonrage.up&((buff.emerald_trance_stacking.stack>=4&set_bonus.tier31_2pc)|(variable.trinket_1_buffs&!cooldown.fire_breath.up&!cooldown.shattering_star.up&!equipped.nymues_unraveling_spindle&trinket.1.cooldown.remains)|(!cooldown.fire_breath.up&!cooldown.shattering_star.up&!set_bonus.tier31_2pc)|active_enemies>=3)&(!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2|variable.trinket_1_exclude)&!variable.trinket_2_manual|trinket.2.proc.any_dps.duration>=fight_remains|trinket.2.cooldown.duration<=60&(variable.next_dragonrage>20|!talent.dragonrage)&(!buff.dragonrage.up|variable.trinket_priority=2)&!variable.trinket_2_manual
+actions.trinkets+=/use_item,slot=trinket1,if=buff.dragonrage.up&((variable.trinket_2_buffs&!cooldown.fire_breath.up&!cooldown.shattering_star.up&!equipped.nymues_unraveling_spindle&trinket.2.cooldown.remains)|(!cooldown.fire_breath.up&!cooldown.shattering_star.up)|active_enemies>=3)&(!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1|variable.trinket_2_exclude)&!variable.trinket_1_manual|trinket.1.proc.any_dps.duration>=fight_remains|trinket.1.cooldown.duration<=60&(variable.next_dragonrage>20|!talent.dragonrage)&(!buff.dragonrage.up|variable.trinket_priority=1)&!variable.trinket_1_manual
+actions.trinkets+=/use_item,slot=trinket2,if=buff.dragonrage.up&((variable.trinket_1_buffs&!cooldown.fire_breath.up&!cooldown.shattering_star.up&!equipped.nymues_unraveling_spindle&trinket.1.cooldown.remains)|(!cooldown.fire_breath.up&!cooldown.shattering_star.up)|active_enemies>=3)&(!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2|variable.trinket_1_exclude)&!variable.trinket_2_manual|trinket.2.proc.any_dps.duration>=fight_remains|trinket.2.cooldown.duration<=60&(variable.next_dragonrage>20|!talent.dragonrage)&(!buff.dragonrage.up|variable.trinket_priority=2)&!variable.trinket_2_manual
 # If only one on use trinket provides a buff, use the other on cooldown. Or if neither trinket provides a buff, use both on cooldown.
 actions.trinkets+=/use_item,slot=trinket1,if=!variable.trinket_1_buffs&(trinket.2.cooldown.remains|!variable.trinket_2_buffs)&(variable.next_dragonrage>20|!talent.dragonrage)&!variable.trinket_1_manual
 actions.trinkets+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.1.cooldown.remains|!variable.trinket_1_buffs)&(variable.next_dragonrage>20|!talent.dragonrage)&!variable.trinket_2_manual

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -63,12 +63,11 @@ actions.aoe+=/deep_breath,if=!buff.dragonrage.up&essence.deficit>3
 actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_burst.stack<buff.essence_burst.max_stack&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
 actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
 # Use Charged Blast stacks if Mass Dis would overcap
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.mass_disintegrate_stacks.up&talent.charged_blast&buff.charged_blast.stack>=12
-actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate
-# Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 15 stacks of CB
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4&!variable.pool_for_id
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=3&talent.volatility&!variable.pool_for_id
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=15
+actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate&(buff.charged_blast.stack<10|!talent.charged_blast)
+# Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 15 stacks of CB Pool CB for DR
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=3&talent.volatility&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=15&(cooldown.dragonrage.remains>gcd.max*4)
 # Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1
 # Yoinked the disintegrate logic from ST

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -65,7 +65,7 @@ actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|
 # Use Charged Blast stacks if Mass Dis would overcap
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate&(buff.charged_blast.stack<10|!talent.charged_blast)
 # Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 12 stacks of CB
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast|talent.engulf)&!variable.pool_for_id
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast|talent.engulf&(!talent.arcane_intensity|!talent.eternitys_span))&!variable.pool_for_id
 actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=12&(cooldown.dragonrage.remains>gcd.max*4)
 # Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -62,6 +62,8 @@ actions.aoe+=/deep_breath,if=!buff.dragonrage.up&essence.deficit>3
 # Send SS when it doesn't overflow EB, without vigor send on CD
 actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_burst.stack<buff.essence_burst.max_stack&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
 actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
+# Use Charged Blast stacks if Mass Dis would overcap
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.mass_disintegrate_stacks.up&talent.charged_blast&buff.charged_blast.stack>=12
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate
 # Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 15 stacks of CB
 actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4&!variable.pool_for_id

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -51,8 +51,8 @@ actions.aoe+=/firestorm,if=talent.feed_the_flames
 actions.aoe+=/call_action_list,name=fb,if=talent.dragonrage&cooldown.dragonrage.up&talent.iridescence
 actions.aoe+=/deep_breath,if=talent.maneuverability&talent.melt_armor
 actions.aoe+=/dragonrage,if=target.time_to_die>=32|fight_remains<30
-# Use tip to get that sweet aggro
-actions.aoe+=/tip_the_scales,if=buff.dragonrage.up&(active_enemies<=3+3*talent.eternitys_span|!cooldown.fire_breath.up)
+# Tip ES at appropiate target count or when playing Flameshaper otherwise Tip FB
+actions.aoe+=/tip_the_scales,if=buff.dragonrage.up&((active_enemies<=3+3*talent.eternitys_span&!talent.engulf)|!cooldown.fire_breath.up)
 # Cast Fire Breath - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.aoe+=/call_action_list,name=fb,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>(variable.dr_prep_time_aoe)|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
 # Cast Eternity Surge - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -65,7 +65,7 @@ actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|
 # Use Charged Blast stacks if Mass Dis would overcap
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate&(buff.charged_blast.stack<10|!talent.charged_blast)
 # Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 12 stacks of CB
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast|talent.engulf)&!variable.pool_for_id
 actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=12&(cooldown.dragonrage.remains>gcd.max*4)
 # Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -64,10 +64,9 @@ actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_bu
 actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
 # Use Charged Blast stacks if Mass Dis would overcap
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate&(buff.charged_blast.stack<10|!talent.charged_blast)
-# Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 15 stacks of CB Pool CB for DR
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=4&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=active_enemies>=3&talent.volatility&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=15&(cooldown.dragonrage.remains>gcd.max*4)
+# Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 12 stacks of CB
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&!variable.pool_for_id&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast)
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=12&(cooldown.dragonrage.remains>gcd.max*4)
 # Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1
 # Yoinked the disintegrate logic from ST

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -40,7 +40,7 @@ actions+=/call_action_list,name=trinkets
 actions+=/run_action_list,name=aoe,if=active_enemies>=3
 actions+=/run_action_list,name=st
 
-# AOE action list; This is kind of a mess again and should prolly be rewritten completely Open with star before DR to save a global and start with a free EB
+# AOE action list; Open with star before DR to save a global and start with a free EB
 actions.aoe=shattering_star,target_if=max:target.health.pct,if=cooldown.dragonrage.up&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
 actions.aoe+=/hover,use_off_gcd=1,if=raid_event.movement.in<6&!buff.hover.up&gcd.remains>=0.5&(buff.mass_disintegrate_stacks.up&talent.mass_disintegrate|active_enemies<=4)
 # Spend firestorm procs ASAP
@@ -53,25 +53,25 @@ actions.aoe+=/deep_breath,if=talent.maneuverability&talent.melt_armor
 actions.aoe+=/dragonrage,if=target.time_to_die>=32|fight_remains<30
 # Tip ES at appropiate target count or when playing Flameshaper otherwise Tip FB
 actions.aoe+=/tip_the_scales,if=buff.dragonrage.up&((active_enemies<=3+3*talent.eternitys_span&!talent.engulf)|!cooldown.fire_breath.up)
-# Cast Fire Breath - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
-actions.aoe+=/call_action_list,name=fb,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>(variable.dr_prep_time_aoe)|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
-# Cast Eternity Surge - stagger for swell/blazing shards outside DR DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
+# Cast Fire Breath DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
+actions.aoe+=/call_action_list,name=fb,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>variable.dr_prep_time_aoe|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
+# Cast Eternity Surge DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.aoe+=/call_action_list,name=es,if=(!talent.dragonrage|buff.dragonrage.up|cooldown.dragonrage.remains>variable.dr_prep_time_aoe|!talent.animosity)&(target.time_to_die>=8|fight_remains<30)
 # Cast DB if not in DR and not going to overflow essence.
 actions.aoe+=/deep_breath,if=!buff.dragonrage.up&essence.deficit>3
 # Send SS when it doesn't overflow EB, without vigor send on CD
 actions.aoe+=/shattering_star,target_if=max:target.health.pct,if=buff.essence_burst.stack<buff.essence_burst.max_stack&talent.arcane_vigor|talent.eternitys_span&active_enemies<=3
 actions.aoe+=/engulf,if=dot.fire_breath_damage.ticking&(!talent.shattering_star|debuff.shattering_star_debuff.up)&cooldown.dragonrage.remains>=27
-# Use Charged Blast stacks if Mass Dis would overcap
+# Use Mass Disintegrate if CB wont't overcap
 actions.aoe+=/disintegrate,target_if=min:debuff.bombardments.remains,if=buff.mass_disintegrate_stacks.up&talent.mass_disintegrate&(buff.charged_blast.stack<10|!talent.charged_blast)
-# Pyre logic Pyre 4T+ Pyre 3T+ if playing Volatility Pyre with 12 stacks of CB
+# Pyre 4T+ - 3T+ with Volatility - 12 stacks of CB - Pool CB for DR
 actions.aoe+=/pyre,target_if=max:target.health.pct,if=(active_enemies>=4|talent.volatility)&(cooldown.dragonrage.remains>gcd.max*4|!talent.charged_blast|talent.engulf&(!talent.arcane_intensity|!talent.eternitys_span))&!variable.pool_for_id
-actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=12&(cooldown.dragonrage.remains>gcd.max*4)
+actions.aoe+=/pyre,target_if=max:target.health.pct,if=buff.charged_blast.stack>=12&cooldown.dragonrage.remains>gcd.max*4
 # Cast LF with leaping flames up if: not playing burnout, burnout is up or the next firebreath is soon.
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=(!talent.burnout|buff.burnout.up|cooldown.fire_breath.remains<=gcd.max*5|buff.scarlet_adaptation.up|buff.ancient_flame.up)&buff.leaping_flames.up&!buff.essence_burst.up&essence.deficit>1
 # Yoinked the disintegrate logic from ST
 actions.aoe+=/disintegrate,target_if=max:target.health.pct,chain=1,early_chain_if=evoker.use_early_chaining&ticks>=2&(raid_event.movement.in>2|buff.hover.up),interrupt_if=evoker.use_clipping&buff.dragonrage.up&ticks>=2&(raid_event.movement.in>2|buff.hover.up),if=(raid_event.movement.in>2|buff.hover.up)&&!variable.pool_for_id
-# Cast LF with burnout and snapfire proc for those juicy insta firestorms
+# Cast LF with burnout to fish for snapfire procs
 actions.aoe+=/living_flame,target_if=max:target.health.pct,if=talent.snapfire&buff.burnout.up
 actions.aoe+=/firestorm
 # Get Ancient Flame as Filler


### PR DESCRIPTION
Went through the AoE and found a couple places to tweak for some better performance across the board. This also includes the changes that are currently live on raidbots, which acts as the base profile.

There are still more gains to be had, but I think this will act as a good starting point.

### Changes
The main performance increase is for CB builds ie. Scalecommander, but there is also a little Flameshaper increase.

1. Make sure that Flameshaper doesn't Tip FB.
2. Pool CB for DR.
3. Send Mass Dis to filler land if it would otherwise overcap CB.
4. Use Pyre with 12 stacks of CB, down from 15.
5. Remove 5t breakpoint for R1 ES.

### Sims
The sims just shows the most relevant builds, but I have tested it across a bunch of different talent setups/gear sets and there doesn't appear to be any outliers that have been nerfed by these changes.

[10t](https://www.raidbots.com/simbot/report/4Tyx1is1moUK61WmUx6LLx)
[8t](https://www.raidbots.com/simbot/report/cXUrpnGWAjNeGzT87MugrL)
[6t](https://www.raidbots.com/simbot/report/n6Zx9VaJ7QqWhrVtybULfF)
[5t](https://www.raidbots.com/simbot/report/j52xuWTNaCxg74pZ9PX8gP)
[3t](https://www.raidbots.com/simbot/report/7aQxhMDpQwKH3QpnNdnEid)
